### PR TITLE
Make compatible with python/pypy 3

### DIFF
--- a/bf.py
+++ b/bf.py
@@ -111,11 +111,12 @@ def run(chars):
             ptr.decrement()
 
         elif char == '.':
-            sys.stdout.write(chr(ptr.get() % 256))
-            sys.stdout.flush()
+            c = ptr.get() % 256
+            c = bytearray([c])
+            os.write(1, c)
 
         elif char == ',':
-            ptr.set(ord(sys.stdin.read(1)))
+            ptr.set(int(os.read(0, 1)))
 
         elif char == '[' and ptr.get() == 0:
             position = get_jump(jump_table, position)

--- a/bf.py
+++ b/bf.py
@@ -111,10 +111,11 @@ def run(chars):
             ptr.decrement()
 
         elif char == '.':
-            os.write(1, chr(ptr.get() % 256))
+            sys.stdout.write(chr(ptr.get() % 256))
+            sys.stdout.flush()
 
         elif char == ',':
-            ptr.set(ord(os.read(0, 1)[0]))
+            ptr.set(ord(sys.stdin.read(1)))
 
         elif char == '[' and ptr.get() == 0:
             position = get_jump(jump_table, position)
@@ -138,17 +139,17 @@ def entry_point(argv):
     try:
         filename = argv[1]
     except IndexError:
-        print "Usage: %s program.bf" % argv[0]
+        print("Usage: %s program.bf" % argv[0])
         return 1
 
-    fp = os.open(filename, os.O_RDONLY, 0777)
+    fp = open(filename, 'r')
     chars = ""
     while True:
-        read = os.read(fp, 4096)
+        read = fp.read(4096)
         if len(read) == 0:
             break
         chars += read
-    os.close(fp)
+    fp.close()
 
     run(remove_comments(chars))
     return 0


### PR DESCRIPTION
This commit changes the code to be python/pypy 3 compatible while still working with python/pypy 2.

There doesn't appear to be performance regressions for doing so, however it may be more difficult to convert to RPython for compiling in your other branch (if that is still ongoing)

For your RPython branch, all that's remaining to change is handling the output, RPython is particularly restrictive with write calls